### PR TITLE
Annotations and main thread enforcement

### DIFF
--- a/flowbinding-common/build.gradle
+++ b/flowbinding-common/build.gradle
@@ -1,13 +1,40 @@
 plugins {
-    id 'kotlin'
+    id 'com.android.library'
+    id 'kotlin-android'
     id 'com.vanniktech.maven.publish'
+}
+
+android {
+    compileSdkVersion androidBuildConfig.compileSdk
+    buildToolsVersion androidBuildConfig.buildTools
+
+    defaultConfig {
+        minSdkVersion androidBuildConfig.minSdk
+        targetSdkVersion androidBuildConfig.targetSdk
+
+        testApplicationId 'reactivecircus.flowbinding.common.test'
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    // TODO replace with https://issuetracker.google.com/issues/72050365 once released.
+    libraryVariants.all { variant ->
+        variant.generateBuildConfigProvider.configure { task ->
+            task.enabled = false
+        }
+    }
 }
 
 dependencies {
     api "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${versions.kotlin}"
     api "org.jetbrains.kotlinx:kotlinx-coroutines-core:${versions.kotlinx.coroutines}"
+    api "androidx.annotation:annotation:${versions.androidx.annotation}"
 
     testImplementation "junit:junit:${versions.junit}"
     testImplementation "com.google.truth:truth:${versions.truth}"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:${versions.kotlinx.coroutines}"
+
+    androidTestImplementation "androidx.test:runner:${versions.androidx.test.runner}"
+    androidTestImplementation "androidx.test:rules:${versions.androidx.test.rules}"
+    androidTestImplementation "com.google.truth:truth:${versions.truth}"
+    androidTestImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:${versions.kotlinx.coroutines}"
 }

--- a/flowbinding-common/gradle.properties
+++ b/flowbinding-common/gradle.properties
@@ -1,4 +1,4 @@
 POM_ARTIFACT_ID=flowbinding-common
 POM_NAME=FlowBinding Common
 POM_DESCRIPTION=Common code shared by FlowBinding libraries
-POM_PACKAGING=jar
+POM_PACKAGING=aar

--- a/flowbinding-common/src/androidTest/java/reactivecircus/flowbinding/common/CheckMainThreadTest.kt
+++ b/flowbinding-common/src/androidTest/java/reactivecircus/flowbinding/common/CheckMainThreadTest.kt
@@ -1,0 +1,32 @@
+package reactivecircus.flowbinding.common
+
+import androidx.test.annotation.UiThreadTest
+import androidx.test.filters.MediumTest
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.single
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Test
+
+@MediumTest
+@ExperimentalCoroutinesApi
+class CheckMainThreadTest {
+
+    private val mainThreadFlow = flow {
+        checkMainThread()
+        emit(true)
+    }
+
+    @Test
+    @UiThreadTest
+    fun checkMainThread_onMainThread() = runBlockingTest {
+        assertThat(mainThreadFlow.single()).isTrue()
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun checkMainThread_notMainThread() = runBlockingTest {
+        mainThreadFlow.collect()
+    }
+}

--- a/flowbinding-common/src/main/AndroidManifest.xml
+++ b/flowbinding-common/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="reactivecircus.flowbinding.common" />

--- a/flowbinding-common/src/main/java/reactivecircus/flowbinding/common/CheckMainThread.kt
+++ b/flowbinding-common/src/main/java/reactivecircus/flowbinding/common/CheckMainThread.kt
@@ -1,0 +1,10 @@
+package reactivecircus.flowbinding.common
+
+import android.os.Looper
+import androidx.annotation.RestrictTo
+import androidx.annotation.RestrictTo.Scope.LIBRARY_GROUP
+
+@RestrictTo(LIBRARY_GROUP)
+fun checkMainThread() = check(Looper.myLooper() == Looper.getMainLooper()) {
+    "Expected to be called on the main thread but was " + Thread.currentThread().name
+}

--- a/flowbinding-common/src/main/java/reactivecircus/flowbinding/common/OfferIfNotClosed.kt
+++ b/flowbinding-common/src/main/java/reactivecircus/flowbinding/common/OfferIfNotClosed.kt
@@ -1,9 +1,12 @@
 package reactivecircus.flowbinding.common
 
+import androidx.annotation.RestrictTo
+import androidx.annotation.RestrictTo.Scope.LIBRARY_GROUP
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.SendChannel
 
+@RestrictTo(LIBRARY_GROUP)
 @UseExperimental(ExperimentalCoroutinesApi::class)
 fun <E> SendChannel<E>.offerIfNotClosed(value: E) = !isClosedForSend && try {
     offer(value)

--- a/flowbinding-common/src/main/java/reactivecircus/flowbinding/common/StartWithCurrentValue.kt
+++ b/flowbinding-common/src/main/java/reactivecircus/flowbinding/common/StartWithCurrentValue.kt
@@ -1,5 +1,6 @@
 package reactivecircus.flowbinding.common
 
+import androidx.annotation.RestrictTo
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.onStart
@@ -7,6 +8,7 @@ import kotlinx.coroutines.flow.onStart
 /**
  * Create a flow that emits the value returned by [block] immediately if [emitImmediately] is true.
  */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @UseExperimental(ExperimentalCoroutinesApi::class)
 fun <T> Flow<T>.startWithCurrentValue(emitImmediately: Boolean, block: () -> T): Flow<T> {
     return if (emitImmediately) onStart { emit(block()) } else this

--- a/flowbinding-viewpager2/build.gradle
+++ b/flowbinding-viewpager2/build.gradle
@@ -29,7 +29,8 @@ android {
 }
 
 dependencies {
-    api project(':flowbinding-common')
+    implementation project(':flowbinding-common')
+
     api "androidx.viewpager2:viewpager2:${versions.androidx.viewPager2}"
     implementation "androidx.fragment:fragment-ktx:${versions.androidx.fragment}"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:${versions.kotlinx.coroutines}"

--- a/flowbinding-viewpager2/src/main/java/reactivecircus/flowbinding/viewpager2/ViewPager2PageScrollStateChangedFlow.kt
+++ b/flowbinding-viewpager2/src/main/java/reactivecircus/flowbinding/viewpager2/ViewPager2PageScrollStateChangedFlow.kt
@@ -1,5 +1,6 @@
 package reactivecircus.flowbinding.viewpager2
 
+import androidx.annotation.CheckResult
 import androidx.viewpager2.widget.ViewPager2
 import androidx.viewpager2.widget.ViewPager2.SCROLL_STATE_DRAGGING
 import androidx.viewpager2.widget.ViewPager2.SCROLL_STATE_IDLE
@@ -9,6 +10,7 @@ import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.conflate
+import reactivecircus.flowbinding.common.checkMainThread
 import reactivecircus.flowbinding.common.offerIfNotClosed
 
 /**
@@ -28,9 +30,11 @@ import reactivecircus.flowbinding.common.offerIfNotClosed
  *     .launchIn(uiScope)
  * ```
  */
+@CheckResult
 @UseExperimental(ExperimentalCoroutinesApi::class)
 fun ViewPager2.pageScrollStateChanges(): Flow<Int> =
     callbackFlow<Int> {
+        checkMainThread()
         val callback = object : ViewPager2.OnPageChangeCallback() {
             override fun onPageScrollStateChanged(state: Int) {
                 offerIfNotClosed(state)

--- a/flowbinding-viewpager2/src/main/java/reactivecircus/flowbinding/viewpager2/ViewPager2PageScrolledFlow.kt
+++ b/flowbinding-viewpager2/src/main/java/reactivecircus/flowbinding/viewpager2/ViewPager2PageScrolledFlow.kt
@@ -2,12 +2,14 @@
 
 package reactivecircus.flowbinding.viewpager2
 
+import androidx.annotation.CheckResult
 import androidx.viewpager2.widget.ViewPager2
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.conflate
+import reactivecircus.flowbinding.common.checkMainThread
 import reactivecircus.flowbinding.common.offerIfNotClosed
 
 /**
@@ -26,9 +28,11 @@ import reactivecircus.flowbinding.common.offerIfNotClosed
  *     .launchIn(uiScope)
  * ```
  */
+@CheckResult
 @UseExperimental(ExperimentalCoroutinesApi::class)
 fun ViewPager2.pageScrollEvents(): Flow<ViewPager2PageScrollEvent> =
     callbackFlow<ViewPager2PageScrollEvent> {
+        checkMainThread()
         val callback = object : ViewPager2.OnPageChangeCallback() {
             override fun onPageScrolled(
                 position: Int,

--- a/flowbinding-viewpager2/src/main/java/reactivecircus/flowbinding/viewpager2/ViewPager2PageSelectedFlow.kt
+++ b/flowbinding-viewpager2/src/main/java/reactivecircus/flowbinding/viewpager2/ViewPager2PageSelectedFlow.kt
@@ -1,11 +1,13 @@
 package reactivecircus.flowbinding.viewpager2
 
+import androidx.annotation.CheckResult
 import androidx.viewpager2.widget.ViewPager2
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.conflate
+import reactivecircus.flowbinding.common.checkMainThread
 import reactivecircus.flowbinding.common.offerIfNotClosed
 import reactivecircus.flowbinding.common.startWithCurrentValue
 
@@ -28,9 +30,11 @@ import reactivecircus.flowbinding.common.startWithCurrentValue
  *     .launchIn(uiScope)
  * ```
  */
+@CheckResult
 @UseExperimental(ExperimentalCoroutinesApi::class)
 fun ViewPager2.pageSelections(emitImmediately: Boolean = false): Flow<Int> =
     callbackFlow<Int> {
+        checkMainThread()
         val callback = object : ViewPager2.OnPageChangeCallback() {
             override fun onPageSelected(position: Int) {
                 offerIfNotClosed(position)


### PR DESCRIPTION
- Added `@RestrictTo(LIBRARY_GROUP)` to internal helper functions in `flowbinding-common`
- Added `@CheckResult` to binding extensions
- Added check to ensure flows are collected on the main thread.