### PR TITLE
Simplify safeOffer.

### DIFF
--- a/flowbinding-common/src/main/java/reactivecircus/flowbinding/common/SafeOffer.kt
+++ b/flowbinding-common/src/main/java/reactivecircus/flowbinding/common/SafeOffer.kt
@@ -2,14 +2,11 @@ package reactivecircus.flowbinding.common
 
 import androidx.annotation.RestrictTo
 import androidx.annotation.RestrictTo.Scope.LIBRARY_GROUP
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.SendChannel
 
 @RestrictTo(LIBRARY_GROUP)
 @UseExperimental(ExperimentalCoroutinesApi::class)
-fun <E> SendChannel<E>.safeOffer(value: E) = !isClosedForSend && try {
-    offer(value)
-} catch (e: CancellationException) {
-    false
+fun <E> SendChannel<E>.safeOffer(value: E): Boolean {
+    return runCatching { offer(value) }.getOrDefault(false)
 }


### PR DESCRIPTION
Simplified **SafeOffer** implementation:
- Replaced try catch block with `runCatching`
- Removed `isClosedForSend` check which should never return true as long as the listeners / callbacks are unregistered in `awaitClose` block.