### PR TITLE
Add AndroidX Lifecycle binding.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ implementation "io.github.reactivecircus.flowbinding:flowbinding-android:${flowb
 implementation "io.github.reactivecircus.flowbinding:flowbinding-appcompat:${flowbinding_version}"
 implementation "io.github.reactivecircus.flowbinding:flowbinding-core:${flowbinding_version}"
 implementation "io.github.reactivecircus.flowbinding:flowbinding-drawerlayout:${flowbinding_version}"
+implementation "io.github.reactivecircus.flowbinding:flowbinding-lifecycle:${flowbinding_version}"
 implementation "io.github.reactivecircus.flowbinding:flowbinding-navigation:${flowbinding_version}"
 implementation "io.github.reactivecircus.flowbinding:flowbinding-preference:${flowbinding_version}"
 implementation "io.github.reactivecircus.flowbinding:flowbinding-recyclerview:${flowbinding_version}"
@@ -149,6 +150,7 @@ List of all bindings available:
 * [AndroidX AppCompat bindings][flowbinding-appcompat]
 * [AndroidX Core bindings][flowbinding-core]
 * [AndroidX DrawerLayout bindings][flowbinding-drawerlayout]
+* [AndroidX Lifecycle bindings][flowbinding-lifecycle]
 * [AndroidX Navigation Component bindings][flowbinding-navigation]
 * [AndroidX Preference bindings][flowbinding-preference]
 * [AndroidX RecyclerView bindings][flowbinding-recyclerview]
@@ -194,6 +196,7 @@ limitations under the License.
 [flowbinding-core]: flowbinding-core/
 [flowbinding-drawerlayout]: flowbinding-drawerlayout/
 [flowbinding-material]: flowbinding-material/
+[flowbinding-lifecycle]: flowbinding-lifecycle/
 [flowbinding-navigation]: flowbinding-navigation/
 [flowbinding-preference]: flowbinding-preference/
 [flowbinding-recyclerview]: flowbinding-recyclerview/

--- a/buildSrc/dependencies.gradle
+++ b/buildSrc/dependencies.gradle
@@ -21,6 +21,7 @@ rootProject.ext.versions = [
                 drawerLayout      : '1.1.0-alpha03',
                 constraintLayout  : '1.1.3',
                 arch              : '2.1.0',
+                lifecycle         : '2.2.0',
                 navigation        : '2.2.0',
                 preference        : '1.1.0',
                 test              : [

--- a/flowbinding-lifecycle/README.md
+++ b/flowbinding-lifecycle/README.md
@@ -1,0 +1,19 @@
+# FlowBinding Lifecycle
+
+This module provides bindings for the **AndroidX Lifecycle** library.
+
+## Transitive Dependency
+
+`androidx.lifecycle:lifecycle-common-java8`
+
+## Download
+
+```groovy
+implementation "io.github.reactivecircus.flowbinding:flowbinding-lifecycle:${flowbinding_version}"
+```
+
+## Available Bindings
+
+```kotlin
+fun Lifecycle.events(): Flow<Lifecycle.Event>
+```

--- a/flowbinding-lifecycle/build.gradle
+++ b/flowbinding-lifecycle/build.gradle
@@ -1,0 +1,26 @@
+plugins {
+    id 'flowbinding-plugin'
+    id 'com.android.library'
+    id 'kotlin-android'
+    id 'com.vanniktech.maven.publish'
+    id 'io.github.reactivecircus.firestorm'
+}
+
+android {
+    defaultConfig {
+        testApplicationId 'reactivecircus.flowbinding.lifecycle.test'
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+}
+
+dependencies {
+    implementation project(':flowbinding-common')
+
+    implementation "androidx.lifecycle:lifecycle-common-java8:${versions.androidx.lifecycle}"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:${versions.kotlinx.coroutines}"
+
+    lintChecks project(":lint-rules")
+
+    androidTestImplementation project(':testing-infra')
+    androidTestImplementation project(':flowbinding-lifecycle:fixtures')
+}

--- a/flowbinding-lifecycle/fixtures/build.gradle
+++ b/flowbinding-lifecycle/fixtures/build.gradle
@@ -1,0 +1,13 @@
+plugins {
+    id 'flowbinding-plugin'
+    id 'com.android.library'
+    id 'kotlin-android'
+}
+
+android.buildFeatures.viewBinding = true
+
+dependencies {
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${versions.kotlin}"
+    implementation "androidx.lifecycle:lifecycle-common-java8:${versions.androidx.lifecycle}"
+    implementation "androidx.fragment:fragment:${versions.androidx.fragment}"
+}

--- a/flowbinding-lifecycle/fixtures/src/main/AndroidManifest.xml
+++ b/flowbinding-lifecycle/fixtures/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="reactivecircus.flowbinding.lifecycle.fixtures" />

--- a/flowbinding-lifecycle/fixtures/src/main/java/reactivecircus/flowbinding/lifecycle/fixtures/LifecycleFragment.kt
+++ b/flowbinding-lifecycle/fixtures/src/main/java/reactivecircus/flowbinding/lifecycle/fixtures/LifecycleFragment.kt
@@ -1,0 +1,5 @@
+package reactivecircus.flowbinding.lifecycle.fixtures
+
+import androidx.fragment.app.Fragment
+
+class LifecycleFragment : Fragment(R.layout.fragment_lifecycle)

--- a/flowbinding-lifecycle/fixtures/src/main/res/layout/fragment_lifecycle.xml
+++ b/flowbinding-lifecycle/fixtures/src/main/res/layout/fragment_lifecycle.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" />

--- a/flowbinding-lifecycle/gradle.properties
+++ b/flowbinding-lifecycle/gradle.properties
@@ -1,0 +1,4 @@
+POM_ARTIFACT_ID=flowbinding-lifecycle
+POM_NAME=FlowBinding Lifecycle
+POM_DESCRIPTION=Kotlin Flow binding APIs for AndroidX Lifecycle
+POM_PACKAGING=aar

--- a/flowbinding-lifecycle/src/androidTest/java/reactivecircus/flowbinding/lifecycle/LifecycleEventFlowTest.kt
+++ b/flowbinding-lifecycle/src/androidTest/java/reactivecircus/flowbinding/lifecycle/LifecycleEventFlowTest.kt
@@ -1,0 +1,36 @@
+package reactivecircus.flowbinding.lifecycle
+
+import androidx.lifecycle.Lifecycle
+import androidx.test.filters.LargeTest
+import org.amshove.kluent.shouldEqual
+import org.junit.Test
+import reactivecircus.flowbinding.lifecycle.fixtures.LifecycleFragment
+import reactivecircus.flowbinding.testing.FlowRecorder
+import reactivecircus.flowbinding.testing.launchTest
+import reactivecircus.flowbinding.testing.recordWith
+
+@LargeTest
+class LifecycleEventFlowTest {
+
+    @Test
+    fun lifecycleEvents() {
+        launchTest<LifecycleFragment> { scenario ->
+            val recorder = FlowRecorder<Lifecycle.Event>(testScope)
+            fragment.lifecycle.events().recordWith(recorder)
+
+            recorder.takeValue() shouldEqual Lifecycle.Event.ON_CREATE
+            recorder.takeValue() shouldEqual Lifecycle.Event.ON_RESUME
+            recorder.assertNoMoreValues()
+
+            scenario.moveToState(Lifecycle.State.CREATED)
+            recorder.takeValue() shouldEqual Lifecycle.Event.ON_PAUSE
+            recorder.takeValue() shouldEqual Lifecycle.Event.ON_STOP
+            recorder.assertNoMoreValues()
+
+            cancelTestScope()
+
+            scenario.moveToState(Lifecycle.State.DESTROYED)
+            recorder.assertNoMoreValues()
+        }
+    }
+}

--- a/flowbinding-lifecycle/src/main/AndroidManifest.xml
+++ b/flowbinding-lifecycle/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="reactivecircus.flowbinding.lifecycle" />

--- a/flowbinding-lifecycle/src/main/java/reactivecircus/flowbinding/lifecycle/LifecycleEventFlow.kt
+++ b/flowbinding-lifecycle/src/main/java/reactivecircus/flowbinding/lifecycle/LifecycleEventFlow.kt
@@ -1,0 +1,45 @@
+package reactivecircus.flowbinding.lifecycle
+
+import androidx.annotation.CheckResult
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.OnLifecycleEvent
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.conflate
+import reactivecircus.flowbinding.common.checkMainThread
+import reactivecircus.flowbinding.common.safeOffer
+
+/**
+ * Create a [Flow] of [Lifecycle.Event]s on the [Lifecycle] instance.
+ *
+ * Note: Created flow keeps a strong reference to the [Lifecycle] instance
+ * until the coroutine that launched the flow collector is cancelled.
+ *
+ * Example of usage:
+ *
+ * ```
+ * lifecycle.events()
+ *     .filter { it == Lifecycle.Event.ON_CREATE }
+ *     .onEach { event ->
+ *          // handle Lifecycle.Event.ON_CREATE event
+ *     }
+ *     .launchIn(uiScope)
+ * ```
+ */
+@CheckResult
+@UseExperimental(ExperimentalCoroutinesApi::class)
+fun Lifecycle.events(): Flow<Lifecycle.Event> = callbackFlow<Lifecycle.Event> {
+    checkMainThread()
+    val observer = object : LifecycleObserver {
+        @OnLifecycleEvent(Lifecycle.Event.ON_ANY)
+        fun onEvent(owner: LifecycleOwner, event: Lifecycle.Event) {
+            safeOffer(event)
+        }
+    }
+    addObserver(observer)
+    awaitClose { removeObserver(observer) }
+}.conflate()

--- a/lint-rules/src/main/java/reactivecircus/flowbinding/lint/MissingListenerRemovalDetector.kt
+++ b/lint-rules/src/main/java/reactivecircus/flowbinding/lint/MissingListenerRemovalDetector.kt
@@ -32,6 +32,7 @@ import java.util.EnumSet
  * `*Listener = *`,
  * `add*Listener(*)`
  * `add*Callback(*)`
+ * `add*Observer(*)`
  * `register*(*)`
  *
  * then one of the following must be present in an `awaitClose` block:
@@ -39,6 +40,7 @@ import java.util.EnumSet
  * `*Listener = null`,
  * `remove*Listener(*)`
  * `remove*Callback(*)`
+ * `remove*Observer(*)`
  * `unregister*(*)`
  */
 @Suppress("UnstableApiUsage", "ComplexCondition", "ReturnCount")
@@ -58,11 +60,17 @@ class MissingListenerRemovalDetector : Detector(), SourceCodeScanner {
         )
 
         private const val CALLBACK_FLOW = "callbackFlow"
+
         private const val AWAIT_CLOSE = "awaitClose"
 
-        private const val PATTERN_ADD_LISTENER_METHOD = "add.+Listener|add.*Callback|register.+"
-        private const val PATTERN_REMOVE_LISTENER_METHOD = "remove.+Listener|remove.*Callback|unregister.+"
+        private const val PATTERN_ADD_LISTENER_METHOD =
+            "add.+Listener|add.*Callback|add.*Observer|register.+"
+
+        private const val PATTERN_REMOVE_LISTENER_METHOD =
+            "remove.+Listener|remove.*Callback|remove.*Observer|unregister.+"
+
         private const val PATTERN_SET_LISTENER = "set.+Listener"
+
         private const val SUFFIX_LISTENER = "listener"
     }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,6 +14,9 @@ includeProject(":flowbinding-core:fixtures", "flowbinding-core/fixtures")
 include(":flowbinding-drawerlayout")
 includeProject(":flowbinding-drawerlayout:fixtures", "flowbinding-drawerlayout/fixtures")
 
+include(":flowbinding-lifecycle")
+includeProject(":flowbinding-lifecycle:fixtures", "flowbinding-lifecycle/fixtures")
+
 include(":flowbinding-material")
 includeProject(":flowbinding-material:fixtures", "flowbinding-material/fixtures")
 

--- a/testing-infra/src/main/java/reactivecircus/flowbinding/testing/TestLauncher.kt
+++ b/testing-infra/src/main/java/reactivecircus/flowbinding/testing/TestLauncher.kt
@@ -4,6 +4,7 @@ import android.view.View
 import androidx.annotation.IdRes
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
+import androidx.fragment.app.testing.FragmentScenario
 import androidx.fragment.app.testing.launchFragmentInContainer
 import androidx.test.espresso.Espresso
 import kotlinx.coroutines.CoroutineScope
@@ -14,12 +15,12 @@ import reactivecircus.blueprint.testing.currentActivity
 import com.google.android.material.R as MaterialR
 
 inline fun <reified F : Fragment> launchTest(
-    block: TestLauncher.() -> Unit
+    block: TestLauncher.(FragmentScenario<F>) -> Unit
 ) {
-    launchFragmentInContainer<F>(themeResId = MaterialR.style.Theme_MaterialComponents_DayNight)
+    val scenario = launchFragmentInContainer<F>(themeResId = MaterialR.style.Theme_MaterialComponents_DayNight)
     Espresso.onIdle()
     val testScope = MainScope()
-    TestLauncher(testScope).block()
+    TestLauncher(testScope).block(scenario)
     testScope.cancel()
 }
 


### PR DESCRIPTION
Resolves #70

Introduced `flowbinding-lifecycle` artifact with binding for Lifecycle events:

```kotlin
lifecycle.events()
    .filter { it == Lifecycle.Event.ON_CREATE }
    .onEach { event ->
         // handle Lifecycle.Event.ON_CREATE event
    }
    .launchIn(uiScope)

```