### PR TITLE
Add binding for OnBackPressedDispatcher.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ implementation "io.github.reactivecircus.flowbinding:flowbinding-android:${flowb
 ### AndroidX Bindings
 
 ```groovy
+implementation "io.github.reactivecircus.flowbinding:flowbinding-activity:${flowbinding_version}"
 implementation "io.github.reactivecircus.flowbinding:flowbinding-appcompat:${flowbinding_version}"
 implementation "io.github.reactivecircus.flowbinding:flowbinding-core:${flowbinding_version}"
 implementation "io.github.reactivecircus.flowbinding:flowbinding-drawerlayout:${flowbinding_version}"
@@ -147,6 +148,7 @@ Our goal is to provide most of the bindings provided by **RxBinding**, while shi
 List of all bindings available:
 
 * [Platform bindings][flowbinding-android]
+* [AndroidX Activity bindings][flowbinding-activity]
 * [AndroidX AppCompat bindings][flowbinding-appcompat]
 * [AndroidX Core bindings][flowbinding-core]
 * [AndroidX DrawerLayout bindings][flowbinding-drawerlayout]
@@ -192,6 +194,7 @@ limitations under the License.
 [flow]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.flow/-flow/
 [kotlinx-coroutines]: https://github.com/Kotlin/kotlinx.coroutines
 [flowbinding-android]: flowbinding-android/
+[flowbinding-activity]: flowbinding-activity/
 [flowbinding-appcompat]: flowbinding-appcompat/
 [flowbinding-core]: flowbinding-core/
 [flowbinding-drawerlayout]: flowbinding-drawerlayout/

--- a/flowbinding-activity/README.md
+++ b/flowbinding-activity/README.md
@@ -1,0 +1,19 @@
+# FlowBinding Activity
+
+This module provides bindings for the **AndroidX Activity** library.
+
+## Transitive Dependency
+
+`androidx.activity:activity-ktx`
+
+## Download
+
+```groovy
+implementation "io.github.reactivecircus.flowbinding:flowbinding-activity:${flowbinding_version}"
+```
+
+## Available Bindings
+
+```kotlin
+fun OnBackPressedDispatcher.backPresses(enabled: Boolean): Flow<Unit>
+```

--- a/flowbinding-activity/build.gradle
+++ b/flowbinding-activity/build.gradle
@@ -1,0 +1,26 @@
+plugins {
+    id 'flowbinding-plugin'
+    id 'com.android.library'
+    id 'kotlin-android'
+    id 'com.vanniktech.maven.publish'
+    id 'io.github.reactivecircus.firestorm'
+}
+
+android {
+    defaultConfig {
+        testApplicationId 'reactivecircus.flowbinding.activity.test'
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+}
+
+dependencies {
+    implementation project(':flowbinding-common')
+
+    implementation "androidx.activity:activity-ktx:${versions.androidx.activity}"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:${versions.kotlinx.coroutines}"
+
+    lintChecks project(":lint-rules")
+
+    androidTestImplementation project(':testing-infra')
+    androidTestImplementation project(':flowbinding-activity:fixtures')
+}

--- a/flowbinding-activity/fixtures/build.gradle
+++ b/flowbinding-activity/fixtures/build.gradle
@@ -1,0 +1,13 @@
+plugins {
+    id 'flowbinding-plugin'
+    id 'com.android.library'
+    id 'kotlin-android'
+}
+
+android.buildFeatures.viewBinding = true
+
+dependencies {
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${versions.kotlin}"
+    implementation "androidx.activity:activity-ktx:${versions.androidx.activity}"
+    implementation "androidx.fragment:fragment:${versions.androidx.fragment}"
+}

--- a/flowbinding-activity/fixtures/src/main/AndroidManifest.xml
+++ b/flowbinding-activity/fixtures/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="reactivecircus.flowbinding.activity.fixtures" />

--- a/flowbinding-activity/fixtures/src/main/java/reactivecircus/flowbinding/activity/fixtures/ActivityFragment.kt
+++ b/flowbinding-activity/fixtures/src/main/java/reactivecircus/flowbinding/activity/fixtures/ActivityFragment.kt
@@ -1,0 +1,5 @@
+package reactivecircus.flowbinding.activity.fixtures
+
+import androidx.fragment.app.Fragment
+
+class ActivityFragment : Fragment(R.layout.fragment_activity)

--- a/flowbinding-activity/fixtures/src/main/res/layout/fragment_activity.xml
+++ b/flowbinding-activity/fixtures/src/main/res/layout/fragment_activity.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" />

--- a/flowbinding-activity/gradle.properties
+++ b/flowbinding-activity/gradle.properties
@@ -1,0 +1,4 @@
+POM_ARTIFACT_ID=flowbinding-activity
+POM_NAME=FlowBinding Activity
+POM_DESCRIPTION=Kotlin Flow binding APIs for AndroidX Activity
+POM_PACKAGING=aar

--- a/flowbinding-activity/src/androidTest/java/reactivecircus/flowbinding/activity/OnBackPressedDispatcherBackPressedFlowTest.kt
+++ b/flowbinding-activity/src/androidTest/java/reactivecircus/flowbinding/activity/OnBackPressedDispatcherBackPressedFlowTest.kt
@@ -1,0 +1,31 @@
+package reactivecircus.flowbinding.activity
+
+import androidx.test.filters.LargeTest
+import org.amshove.kluent.shouldEqual
+import org.junit.Test
+import reactivecircus.blueprint.testing.action.pressBack
+import reactivecircus.flowbinding.activity.fixtures.ActivityFragment
+import reactivecircus.flowbinding.testing.FlowRecorder
+import reactivecircus.flowbinding.testing.launchTest
+import reactivecircus.flowbinding.testing.recordWith
+
+@LargeTest
+class OnBackPressedDispatcherBackPressedFlowTest {
+
+    @Test
+    fun onBackPressedDispatcherBackPresses() {
+        launchTest<ActivityFragment> {
+            val recorder = FlowRecorder<Unit>(testScope)
+            fragment.requireActivity().onBackPressedDispatcher.backPresses(owner = fragment).recordWith(recorder)
+
+            pressBack()
+            recorder.takeValue() shouldEqual Unit
+            recorder.assertNoMoreValues()
+
+            cancelTestScope()
+
+            pressBack()
+            recorder.assertNoMoreValues()
+        }
+    }
+}

--- a/flowbinding-activity/src/main/AndroidManifest.xml
+++ b/flowbinding-activity/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="reactivecircus.flowbinding.activity" />

--- a/flowbinding-activity/src/main/java/reactivecircus/flowbinding/activity/OnBackPressedDispatcherBackPressedFlow.kt
+++ b/flowbinding-activity/src/main/java/reactivecircus/flowbinding/activity/OnBackPressedDispatcherBackPressedFlow.kt
@@ -1,0 +1,45 @@
+package reactivecircus.flowbinding.activity
+
+import androidx.activity.OnBackPressedCallback
+import androidx.activity.OnBackPressedDispatcher
+import androidx.annotation.CheckResult
+import androidx.lifecycle.LifecycleOwner
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.conflate
+import reactivecircus.flowbinding.common.checkMainThread
+import reactivecircus.flowbinding.common.safeOffer
+
+/**
+ * Create a [Flow] of on back pressed events on the [OnBackPressedDispatcher] instance.
+ *
+ * @param owner the LifecycleOwner which controls when the callback should be invoked.
+ *
+ * Note: Created flow keeps a strong reference to the [OnBackPressedDispatcher] instance
+ * until the coroutine that launched the flow collector is cancelled.
+ *
+ * Example of usage:
+ *
+ * ```
+ * onBackPressedDispatcher.backPresses(lifecycleOwner)
+ *     .onEach {
+ *          // handle back pressed
+ *     }
+ *     .launchIn(uiScope)
+ * ```
+ */
+@CheckResult
+@UseExperimental(ExperimentalCoroutinesApi::class)
+fun OnBackPressedDispatcher.backPresses(owner: LifecycleOwner): Flow<Unit> =
+    callbackFlow<Unit> {
+        checkMainThread()
+        val callback = object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                safeOffer(Unit)
+            }
+        }
+        addCallback(owner, callback)
+        awaitClose { callback.remove() }
+    }.conflate()

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,6 +5,9 @@ include(":flowbinding-common")
 include(":flowbinding-android")
 includeProject(":flowbinding-android:fixtures", "flowbinding-android/fixtures")
 
+include(":flowbinding-activity")
+includeProject(":flowbinding-activity:fixtures", "flowbinding-activity/fixtures")
+
 include(":flowbinding-appcompat")
 includeProject(":flowbinding-appcompat:fixtures", "flowbinding-appcompat/fixtures")
 


### PR DESCRIPTION
Resolves #71 

Introduced a new `flowbinding-activity` artifact with a binding on `OnBackPressedDispatcher`.

Note that [`OnBackPressedCallback`](https://developer.android.com/reference/androidx/activity/OnBackPressedCallback.html) from `androidx.activity` supports enabling / disabling the callback dynamically but since the binding only exposes a `Flow<Unit>`, consumers will need to use some other mechanism (e.g. `filter`, `flatMapConcat`) to decide whether to process the on back pressed events. 