### PR TITLE
Fix packaging options where *.kotlin_module were excluded.

### DIFF
--- a/buildSrc/src/main/kotlin/reactivecircus/flowbinding/ProjectConfigurations.kt
+++ b/buildSrc/src/main/kotlin/reactivecircus/flowbinding/ProjectConfigurations.kt
@@ -82,8 +82,8 @@ fun LibraryExtension.configureAndroidLibraryOptions(project: Project) {
 
     packagingOptions {
         pickFirst("META-INF/AL2.0")
-        exclude("META-INF/LGPL2.1")
-        exclude("META-INF/*.kotlin_module")
+        pickFirst("META-INF/LGPL2.1")
+        pickFirst("META-INF/*.kotlin_module")
     }
 }
 


### PR DESCRIPTION
Fixes #104 