### PR TITLE
Update API docs with Dokka 1.4.0

### DIFF
--- a/.buildscript/deploy_website.sh
+++ b/.buildscript/deploy_website.sh
@@ -16,7 +16,7 @@ git clone "$REPO" $DIR
 cd $DIR
 
 # Generate API docs
-./gradlew dokka
+./gradlew dokkaHtmlMultiModule
 
 # Copy *.md files into docs directory
 cp README.md docs/index.md

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,24 +11,20 @@ buildscript {
     dependencies {
         classpath("com.android.tools.build:gradle:${versions.getValue("androidGradlePlugin")}")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.getValue("kotlin")}")
-        classpath("org.jetbrains.kotlinx:binary-compatibility-validator:${versions.getValue("binaryCompatibilityValidator")}")
         classpath("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:${versions.getValue("detekt")}")
         classpath("com.vanniktech:gradle-maven-publish-plugin:${versions.getValue("mavenPublishPlugin")}")
         classpath("io.github.reactivecircus.firestorm:firestorm-gradle-plugin:${versions.getValue("firestormGradlePlugin")}")
-        classpath("org.jetbrains.dokka:dokka-gradle-plugin:${versions.getValue("dokka")}")
     }
 }
 
 plugins {
     `flowbinding-plugin`
+    id("org.jetbrains.dokka") version "1.4.0"
 }
 
-apply(plugin = "binary-compatibility-validator")
-
-configure<kotlinx.validation.ApiValidationExtension> {
-    ignoredProjects.addAll(
-        listOf("fixtures", "testing-infra", "lint-rules")
-    )
+tasks.dokkaHtmlMultiModule.configure {
+    outputDirectory.set(rootDir.resolve("docs/api"))
+    documentationFileName.set("README.md")
 }
 
 subprojects {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.getValue("kotlin")}")
     implementation("com.android.tools.build:gradle:${versions.getValue("androidGradlePlugin")}")
     implementation("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:${versions.getValue("detekt")}")
+    implementation("org.jetbrains.kotlinx:binary-compatibility-validator:${versions.getValue("binaryCompatibilityValidator")}")
 }
 
 gradlePlugin {

--- a/buildSrc/dependencies.gradle
+++ b/buildSrc/dependencies.gradle
@@ -1,9 +1,8 @@
 rootProject.ext.versions = [
         androidGradlePlugin         : '4.1.0-rc02',
         androidLint                 : '27.1.0-rc02',
-        mavenPublishPlugin          : '0.12.0',
+        mavenPublishPlugin          : '0.13.0',
         firestormGradlePlugin       : '0.1.1',
-        dokka                       : '0.10.1',
         binaryCompatibilityValidator: '0.2.3',
         kotlin                      : '1.4.0',
         detekt                      : '1.12.0',

--- a/buildSrc/src/main/kotlin/reactivecircus/flowbinding/ApiCheckConfigs.kt
+++ b/buildSrc/src/main/kotlin/reactivecircus/flowbinding/ApiCheckConfigs.kt
@@ -1,0 +1,37 @@
+package reactivecircus.flowbinding
+
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.withType
+import kotlinx.validation.ApiValidationExtension
+import kotlinx.validation.BinaryCompatibilityValidatorPlugin
+
+/**
+ * Apply and configure the [BinaryCompatibilityValidatorPlugin] for the [Project].
+ */
+internal fun Project.configureBinaryCompatibilityValidation() {
+    pluginManager.apply(BinaryCompatibilityValidatorPlugin::class.java)
+    plugins.withType<BinaryCompatibilityValidatorPlugin> {
+        extensions.configure<ApiValidationExtension> {
+            ignoredProjects.addAll(IGNORED_PROJECTS)
+        }
+    }
+}
+
+private val IGNORED_PROJECTS = listOf(
+    "flowbinding-activity-fixtures",
+    "flowbinding-android-fixtures",
+    "flowbinding-appcompat-fixtures",
+    "flowbinding-core-fixtures",
+    "flowbinding-drawerlayout-fixtures",
+    "flowbinding-lifecycle-fixtures",
+    "flowbinding-material-fixtures",
+    "flowbinding-navigation-fixtures",
+    "flowbinding-preference-fixtures",
+    "flowbinding-recyclerview-fixtures",
+    "flowbinding-swiperefreshlayout-fixtures",
+    "flowbinding-viewpager-fixtures",
+    "flowbinding-viewpager2-fixtures",
+    "testing-infra",
+    "lint-rules"
+)

--- a/buildSrc/src/main/kotlin/reactivecircus/flowbinding/ProjectConfigurations.kt
+++ b/buildSrc/src/main/kotlin/reactivecircus/flowbinding/ProjectConfigurations.kt
@@ -23,6 +23,8 @@ fun Project.configureRootProject() {
     tasks.register("clean", Delete::class.java) {
         delete(rootProject.buildDir)
     }
+    // configure binary compatibility validation (API checks)
+    configureBinaryCompatibilityValidation()
 }
 
 /**

--- a/flowbinding-activity/build.gradle
+++ b/flowbinding-activity/build.gradle
@@ -7,13 +7,6 @@ plugins {
     id 'org.jetbrains.dokka'
 }
 
-afterEvaluate { project ->
-    project.tasks.dokka {
-        outputDirectory = "$rootDir/docs/api"
-        outputFormat = 'gfm'
-    }
-}
-
 android {
     defaultConfig {
         testApplicationId 'reactivecircus.flowbinding.activity.test'
@@ -37,5 +30,5 @@ dependencies {
     lintChecks project(":lint-rules")
 
     androidTestImplementation project(':testing-infra')
-    androidTestImplementation project(':flowbinding-activity:fixtures')
+    androidTestImplementation project(':flowbinding-activity-fixtures')
 }

--- a/flowbinding-android/build.gradle
+++ b/flowbinding-android/build.gradle
@@ -7,13 +7,6 @@ plugins {
     id 'org.jetbrains.dokka'
 }
 
-afterEvaluate { project ->
-    project.tasks.dokka {
-        outputDirectory = "$rootDir/docs/api"
-        outputFormat = 'gfm'
-    }
-}
-
 android {
     defaultConfig {
         testApplicationId 'reactivecircus.flowbinding.android.test'
@@ -36,5 +29,5 @@ dependencies {
     lintChecks project(":lint-rules")
 
     androidTestImplementation project(':testing-infra')
-    androidTestImplementation project(':flowbinding-android:fixtures')
+    androidTestImplementation project(':flowbinding-android-fixtures')
 }

--- a/flowbinding-appcompat/build.gradle
+++ b/flowbinding-appcompat/build.gradle
@@ -7,13 +7,6 @@ plugins {
     id 'org.jetbrains.dokka'
 }
 
-afterEvaluate { project ->
-    project.tasks.dokka {
-        outputDirectory = "$rootDir/docs/api"
-        outputFormat = 'gfm'
-    }
-}
-
 android {
     defaultConfig {
         testApplicationId 'reactivecircus.flowbinding.appcompat.test'
@@ -37,5 +30,5 @@ dependencies {
     lintChecks project(":lint-rules")
 
     androidTestImplementation project(':testing-infra')
-    androidTestImplementation project(':flowbinding-appcompat:fixtures')
+    androidTestImplementation project(':flowbinding-appcompat-fixtures')
 }

--- a/flowbinding-common/README.md
+++ b/flowbinding-common/README.md
@@ -1,0 +1,1 @@
+# FlowBinding Common

--- a/flowbinding-common/build.gradle
+++ b/flowbinding-common/build.gradle
@@ -7,13 +7,6 @@ plugins {
     id 'org.jetbrains.dokka'
 }
 
-afterEvaluate { project ->
-    project.tasks.dokka {
-        outputDirectory = "$rootDir/docs/api"
-        outputFormat = 'gfm'
-    }
-}
-
 android {
     defaultConfig {
         testApplicationId 'reactivecircus.flowbinding.common.test'

--- a/flowbinding-core/build.gradle
+++ b/flowbinding-core/build.gradle
@@ -7,13 +7,6 @@ plugins {
     id 'org.jetbrains.dokka'
 }
 
-afterEvaluate { project ->
-    project.tasks.dokka {
-        outputDirectory = "$rootDir/docs/api"
-        outputFormat = 'gfm'
-    }
-}
-
 android {
     defaultConfig {
         testApplicationId 'reactivecircus.flowbinding.core.test'
@@ -37,5 +30,5 @@ dependencies {
     lintChecks project(":lint-rules")
 
     androidTestImplementation project(':testing-infra')
-    androidTestImplementation project(':flowbinding-core:fixtures')
+    androidTestImplementation project(':flowbinding-core-fixtures')
 }

--- a/flowbinding-drawerlayout/build.gradle
+++ b/flowbinding-drawerlayout/build.gradle
@@ -7,13 +7,6 @@ plugins {
     id 'org.jetbrains.dokka'
 }
 
-afterEvaluate { project ->
-    project.tasks.dokka {
-        outputDirectory = "$rootDir/docs/api"
-        outputFormat = 'gfm'
-    }
-}
-
 android {
     defaultConfig {
         testApplicationId 'reactivecircus.flowbinding.drawerlayout.test'
@@ -37,5 +30,5 @@ dependencies {
     lintChecks project(":lint-rules")
 
     androidTestImplementation project(':testing-infra')
-    androidTestImplementation project(':flowbinding-drawerlayout:fixtures')
+    androidTestImplementation project(':flowbinding-drawerlayout-fixtures')
 }

--- a/flowbinding-lifecycle/build.gradle
+++ b/flowbinding-lifecycle/build.gradle
@@ -7,13 +7,6 @@ plugins {
     id 'org.jetbrains.dokka'
 }
 
-afterEvaluate { project ->
-    project.tasks.dokka {
-        outputDirectory = "$rootDir/docs/api"
-        outputFormat = 'gfm'
-    }
-}
-
 android {
     defaultConfig {
         testApplicationId 'reactivecircus.flowbinding.lifecycle.test'
@@ -37,6 +30,6 @@ dependencies {
     lintChecks project(":lint-rules")
 
     androidTestImplementation project(':testing-infra')
-    androidTestImplementation project(':flowbinding-lifecycle:fixtures')
+    androidTestImplementation project(':flowbinding-lifecycle-fixtures')
     androidTestImplementation "androidx.lifecycle:lifecycle-runtime-testing:${versions.androidx.lifecycle}"
 }

--- a/flowbinding-material/build.gradle
+++ b/flowbinding-material/build.gradle
@@ -7,13 +7,6 @@ plugins {
     id 'org.jetbrains.dokka'
 }
 
-afterEvaluate { project ->
-    project.tasks.dokka {
-        outputDirectory = "$rootDir/docs/api"
-        outputFormat = 'gfm'
-    }
-}
-
 android {
     defaultConfig {
         testApplicationId 'reactivecircus.flowbinding.material.test'
@@ -38,5 +31,5 @@ dependencies {
     lintChecks project(":lint-rules")
 
     androidTestImplementation project(':testing-infra')
-    androidTestImplementation project(':flowbinding-material:fixtures')
+    androidTestImplementation project(':flowbinding-material-fixtures')
 }

--- a/flowbinding-navigation/build.gradle
+++ b/flowbinding-navigation/build.gradle
@@ -7,13 +7,6 @@ plugins {
     id 'org.jetbrains.dokka'
 }
 
-afterEvaluate { project ->
-    project.tasks.dokka {
-        outputDirectory = "$rootDir/docs/api"
-        outputFormat = 'gfm'
-    }
-}
-
 android {
     defaultConfig {
         testApplicationId 'reactivecircus.flowbinding.navigation.test'
@@ -37,6 +30,6 @@ dependencies {
     lintChecks project(":lint-rules")
 
     androidTestImplementation project(':testing-infra')
-    androidTestImplementation project(':flowbinding-navigation:fixtures')
+    androidTestImplementation project(':flowbinding-navigation-fixtures')
     androidTestImplementation "androidx.navigation:navigation-fragment-ktx:${versions.androidx.navigation}"
 }

--- a/flowbinding-preference/build.gradle
+++ b/flowbinding-preference/build.gradle
@@ -7,13 +7,6 @@ plugins {
     id 'org.jetbrains.dokka'
 }
 
-afterEvaluate { project ->
-    project.tasks.dokka {
-        outputDirectory = "$rootDir/docs/api"
-        outputFormat = 'gfm'
-    }
-}
-
 android {
     defaultConfig {
         testApplicationId 'reactivecircus.flowbinding.preference.test'
@@ -37,5 +30,5 @@ dependencies {
     lintChecks project(":lint-rules")
 
     androidTestImplementation project(':testing-infra')
-    androidTestImplementation project(':flowbinding-preference:fixtures')
+    androidTestImplementation project(':flowbinding-preference-fixtures')
 }

--- a/flowbinding-recyclerview/build.gradle
+++ b/flowbinding-recyclerview/build.gradle
@@ -7,13 +7,6 @@ plugins {
     id 'org.jetbrains.dokka'
 }
 
-afterEvaluate { project ->
-    project.tasks.dokka {
-        outputDirectory = "$rootDir/docs/api"
-        outputFormat = 'gfm'
-    }
-}
-
 android {
     defaultConfig {
         testApplicationId 'reactivecircus.flowbinding.recyclerview.test'
@@ -37,5 +30,5 @@ dependencies {
     lintChecks project(":lint-rules")
 
     androidTestImplementation project(':testing-infra')
-    androidTestImplementation project(':flowbinding-recyclerview:fixtures')
+    androidTestImplementation project(':flowbinding-recyclerview-fixtures')
 }

--- a/flowbinding-swiperefreshlayout/build.gradle
+++ b/flowbinding-swiperefreshlayout/build.gradle
@@ -7,13 +7,6 @@ plugins {
     id 'org.jetbrains.dokka'
 }
 
-afterEvaluate { project ->
-    project.tasks.dokka {
-        outputDirectory = "$rootDir/docs/api"
-        outputFormat = 'gfm'
-    }
-}
-
 android {
     defaultConfig {
         testApplicationId 'reactivecircus.flowbinding.swiperefreshlayout.test'
@@ -37,5 +30,5 @@ dependencies {
     lintChecks project(":lint-rules")
 
     androidTestImplementation project(':testing-infra')
-    androidTestImplementation project(':flowbinding-swiperefreshlayout:fixtures')
+    androidTestImplementation project(':flowbinding-swiperefreshlayout-fixtures')
 }

--- a/flowbinding-viewpager/build.gradle
+++ b/flowbinding-viewpager/build.gradle
@@ -7,13 +7,6 @@ plugins {
     id 'org.jetbrains.dokka'
 }
 
-afterEvaluate { project ->
-    project.tasks.dokka {
-        outputDirectory = "$rootDir/docs/api"
-        outputFormat = 'gfm'
-    }
-}
-
 android {
     defaultConfig {
         testApplicationId 'reactivecircus.flowbinding.viewpager.test'
@@ -38,5 +31,5 @@ dependencies {
     lintChecks project(":lint-rules")
 
     androidTestImplementation project(':testing-infra')
-    androidTestImplementation project(':flowbinding-viewpager:fixtures')
+    androidTestImplementation project(':flowbinding-viewpager-fixtures')
 }

--- a/flowbinding-viewpager2/build.gradle
+++ b/flowbinding-viewpager2/build.gradle
@@ -7,13 +7,6 @@ plugins {
     id 'org.jetbrains.dokka'
 }
 
-afterEvaluate { project ->
-    project.tasks.dokka {
-        outputDirectory = "$rootDir/docs/api"
-        outputFormat = 'gfm'
-    }
-}
-
 android {
     defaultConfig {
         testApplicationId 'reactivecircus.flowbinding.viewpager2.test'
@@ -38,5 +31,5 @@ dependencies {
     lintChecks project(":lint-rules")
 
     androidTestImplementation project(':testing-infra')
-    androidTestImplementation project(':flowbinding-viewpager2:fixtures')
+    androidTestImplementation project(':flowbinding-viewpager2-fixtures')
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,20 +44,7 @@ nav:
   - 'AndroidX ViewPager2 Bindings': flowbinding-viewpager2/index.md
   - 'Material Components Bindings': flowbinding-material/index.md
   - 'Change Log': changelog.md
-  - 'API':
-      - 'flowbinding-activity': api/flowbinding-activity/index.md
-      - 'flowbinding-android': api/flowbinding-android/index.md
-      - 'flowbinding-appcompat': api/flowbinding-appcompat/index.md
-      - 'flowbinding-common': api/flowbinding-common/index.md
-      - 'flowbinding-core': api/flowbinding-core/index.md
-      - 'flowbinding-drawerlayout': api/flowbinding-drawerlayout/index.md
-      - 'flowbinding-lifecycle': api/flowbinding-lifecycle/index.md
-      - 'flowbinding-material': api/flowbinding-material/index.md
-      - 'flowbinding-navigation': api/flowbinding-navigation/index.md
-      - 'flowbinding-preference': api/flowbinding-preference/index.md
-      - 'flowbinding-recyclerview': api/flowbinding-recyclerview/index.md
-      - 'flowbinding-swiperefreshlayout': api/flowbinding-swiperefreshlayout/index.md
-      - 'flowbinding-viewpager2': api/flowbinding-viewpager2/index.md
+  - 'API Docs': api/-modules.html" target="_blank
 
 markdown_extensions:
   - admonition

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,43 +3,43 @@ rootProject.name = "FlowBinding"
 include(":flowbinding-common")
 
 include(":flowbinding-android")
-includeProject(":flowbinding-android:fixtures", "flowbinding-android/fixtures")
+includeProject(":flowbinding-android-fixtures", "flowbinding-android/fixtures")
 
 include(":flowbinding-activity")
-includeProject(":flowbinding-activity:fixtures", "flowbinding-activity/fixtures")
+includeProject(":flowbinding-activity-fixtures", "flowbinding-activity/fixtures")
 
 include(":flowbinding-appcompat")
-includeProject(":flowbinding-appcompat:fixtures", "flowbinding-appcompat/fixtures")
+includeProject(":flowbinding-appcompat-fixtures", "flowbinding-appcompat/fixtures")
 
 include(":flowbinding-core")
-includeProject(":flowbinding-core:fixtures", "flowbinding-core/fixtures")
+includeProject(":flowbinding-core-fixtures", "flowbinding-core/fixtures")
 
 include(":flowbinding-drawerlayout")
-includeProject(":flowbinding-drawerlayout:fixtures", "flowbinding-drawerlayout/fixtures")
+includeProject(":flowbinding-drawerlayout-fixtures", "flowbinding-drawerlayout/fixtures")
 
 include(":flowbinding-lifecycle")
-includeProject(":flowbinding-lifecycle:fixtures", "flowbinding-lifecycle/fixtures")
+includeProject(":flowbinding-lifecycle-fixtures", "flowbinding-lifecycle/fixtures")
 
 include(":flowbinding-material")
-includeProject(":flowbinding-material:fixtures", "flowbinding-material/fixtures")
+includeProject(":flowbinding-material-fixtures", "flowbinding-material/fixtures")
 
 include(":flowbinding-navigation")
-includeProject(":flowbinding-navigation:fixtures", "flowbinding-navigation/fixtures")
+includeProject(":flowbinding-navigation-fixtures", "flowbinding-navigation/fixtures")
 
 include(":flowbinding-preference")
-includeProject(":flowbinding-preference:fixtures", "flowbinding-preference/fixtures")
+includeProject(":flowbinding-preference-fixtures", "flowbinding-preference/fixtures")
 
 include(":flowbinding-recyclerview")
-includeProject(":flowbinding-recyclerview:fixtures", "flowbinding-recyclerview/fixtures")
+includeProject(":flowbinding-recyclerview-fixtures", "flowbinding-recyclerview/fixtures")
 
 include(":flowbinding-swiperefreshlayout")
-includeProject(":flowbinding-swiperefreshlayout:fixtures", "flowbinding-swiperefreshlayout/fixtures")
+includeProject(":flowbinding-swiperefreshlayout-fixtures", "flowbinding-swiperefreshlayout/fixtures")
 
 include(":flowbinding-viewpager")
-includeProject(":flowbinding-viewpager:fixtures", "flowbinding-viewpager/fixtures")
+includeProject(":flowbinding-viewpager-fixtures", "flowbinding-viewpager/fixtures")
 
 include(":flowbinding-viewpager2")
-includeProject(":flowbinding-viewpager2:fixtures", "flowbinding-viewpager2/fixtures")
+includeProject(":flowbinding-viewpager2-fixtures", "flowbinding-viewpager2/fixtures")
 
 include(":testing-infra")
 


### PR DESCRIPTION
- Update to Dokka 1.4.0 and Maven publish plugin 0.13.0
- Generate API docs as HTML and update mkdocs website to link the docs as an external link
- Move binary-compatibility-validator configs to buildSrc